### PR TITLE
About:profiles and Incognito buttons in the "people" button

### DIFF
--- a/Profile Folder/chrome/JS/Geckium_peoplemenu.uc.js
+++ b/Profile Folder/chrome/JS/Geckium_peoplemenu.uc.js
@@ -1,0 +1,51 @@
+// ==UserScript==
+// @name        Geckium - People Menu
+// @author		ImSwordQueen
+// @loadorder   4
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    // Retry function to ensure elements exist before trying to add event listeners
+    function waitForElement(selector, callback, maxRetries = 20, delay = 500) {
+        let retries = 0;
+
+        const interval = setInterval(function() {
+            const element = document.querySelector(selector);
+            if (element || retries >= maxRetries) {
+                clearInterval(interval);
+                if (element) {
+                    callback(element);
+                } else {
+                }
+            }
+            retries++;
+        }, delay);
+    }
+
+    function modifyButtons() {
+        // Firefox Monitor
+        waitForElement('#PanelUI-fxa-menu #PanelUI-fxa-menu-monitor-button', function(monitorButton) {
+
+                monitorButton.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    openTrustedLinkIn("about:profiles", "tab")
+                });
+        });
+
+        // Firefox R(D)elay
+        waitForElement('#PanelUI-fxa-menu #PanelUI-fxa-menu-relay-button', function(relayButton) {
+
+                relayButton.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    OpenBrowserWindow({ private: true });
+                });
+        });
+    }
+
+    window.addEventListener('load', function() {
+        modifyButtons();
+    });
+
+})();

--- a/Profile Folder/chrome/styles/partials/chrome/chrome-1/panel/_panelUI-shared.scss
+++ b/Profile Folder/chrome/styles/partials/chrome/chrome-1/panel/_panelUI-shared.scss
@@ -48,8 +48,8 @@
 }
 
 #PanelUI-fxa-menu {
-	#PanelUI-fxa-menu-monitor-button,
-	#PanelUI-fxa-menu-relay-button,
+	#PanelUI-fxa-menu-monitor-button #cta-menu-header-description,
+	#PanelUI-fxa-menu-relay-button #cta-menu-header-description,
 	#PanelUI-fxa-menu-vpn-button {
 		display: none !important;
 	}


### PR DESCRIPTION
This PR adds the code that makes the "Monitor" and "Relay" buttons become the "about:profiles" and "Incognito" buttons like to what Chrome does.