### PR TITLE
feat(canary): implement canary update checker + small ci change

### DIFF
--- a/.github/workflows/buildcanary.yml
+++ b/.github/workflows/buildcanary.yml
@@ -34,6 +34,7 @@ jobs:
             echo "should_run=true" >> $GITHUB_OUTPUT
           fi
   build:
+    name: Build Canary
     needs: check_date
     if: ${{ needs.check_date.outputs.should_run != 'false' || github.event_name != 'schedule' }}
     runs-on: ubuntu-latest

--- a/Profile Folder/chrome/JS/Geckium_updater.uc.js
+++ b/Profile Folder/chrome/JS/Geckium_updater.uc.js
@@ -133,15 +133,14 @@ async function gkCheckForUpdatesCanary() {
             let hasUpdate = false;
             for (let run of workflow_runs.workflow_runs) {
                 if (hasUpdate) break;
-                console.log("We found a run with the following commit hash: " + run.head_commit.id.substring(0, 7) + " current version: " + gkverraw);
+
                 // check if the latest successful run is newer than the current version. I am assuming they are in order of when they were run.
                 if (run.head_commit.id.substring(0, 7) == gkverraw) {
                     // We are on the newest version, abort.
-                    console.log("We are on the newest version, aborting.");
                     document.documentElement.setAttribute("gkcanupdate", "false");
                     break;
                 }
-                console.log("Not using latest run, checking for artifacts.");
+
                 // We know that the latest run is newer than the current version, but we do not know if it actually built anything.
                 // We need to check the artifacts to see if there is a build.
                 fetch(run.artifacts_url, {cache: "reload", headers: {"X-GitHub-Api-Version": "2022-11-28", "Accept": "application/vnd.github+json", "UserAgent": "GeckiumUpdater/1.0"}})
@@ -150,10 +149,7 @@ async function gkCheckForUpdatesCanary() {
                         if (artifacts.total_count > 0) {
                             // We have a build, we can update.
                             document.documentElement.setAttribute("gkcanupdate", "true");
-                            console.log("We have a build, we can update.");
                             hasUpdate = true;
-                        } else {
-                            console.log("No artifacts found, skipping.");
                         }
                     });
             }

--- a/Profile Folder/chrome/JS/modules/GeckiumUpdater.sys.mjs
+++ b/Profile Folder/chrome/JS/modules/GeckiumUpdater.sys.mjs
@@ -25,6 +25,28 @@ export class gkUpdater {
 			throw error; // re-throw the error to propagate it further if needed
 		}
 	}
+	static async getChannel() {
+		try {
+			const response = await fetch("chrome://userchrome/content/version.json");
+			const data = await response.json();
+
+			return data.update_channel;
+		} catch (error) {
+			console.error('Error fetching JSON:', error);
+			throw error; // re-throw the error to propagate it further if needed
+		}
+	}
+	static async getRawVersion() {
+		try {
+			const response = await fetch("chrome://userchrome/content/version.json");
+			const data = await response.json();
+
+			return data.version;
+		} catch (error) {
+			console.error('Error fetching JSON:', error);
+			throw error; // re-throw the error to propagate it further if needed
+		}
+	}
 	
 	static checkForUpdates() {
 		return "W.I.P."


### PR DESCRIPTION
This makes the check for updates function compatible with canary builds, thru the github actions API. Also fixes a small thing that was bugging me with actions.

Also does some misc. changes to how Geckium checks release updates.