### PR TITLE
Updated / Fixed Japanese localization

### DIFF
--- a/Profile Folder/chrome/locale/ja/dtd/gm.dtd
+++ b/Profile Folder/chrome/locale/ja/dtd/gm.dtd
@@ -1,4 +1,4 @@
 <!ENTITY gm.openInTabNext		"次回からこの画面を新しいタブで表示する">
-<!ENTITY gm.clickSoundFeedback	"[!!! Çℓïçƙ ƨôúñδ ƒèèδβáçƙ !!!]">
+<!ENTITY gm.clickSoundFeedback	"クリックした時のサウンドフィードバック"> <!-- Translated like "Sound feedback when clicked", but maybe better with only "Sound feedback"? -->
 
 <!ENTITY gm.goToPage "このページに移動する">


### PR DESCRIPTION
hi

i am going to eat pizza

 - Translated missing locales
 - "People" translation is replaced from "アバター" to "プロファイル" because macOS versions of Chrome is translating People menu like that
 - Added comment-out in `gm.clickSoundFeedback`
 - still don't know how should i translate `gsettings.showChrOSPeopleDescription` one