### PR TITLE
Add marble restrictions for the firefox fork okaeri

### DIFF
--- a/Profile Folder/chrome/JS/Geckium_forkAdj.uc.js
+++ b/Profile Folder/chrome/JS/Geckium_forkAdj.uc.js
@@ -296,7 +296,7 @@ class gkMarbleAdj {
 		}
 	}
 }
-if (AppConstants.MOZ_APP_NAME == "marble") {
+if (AppConstants.MOZ_APP_NAME == "marble" || AppConstants.MOZ_APP_NAME == "okaeri") {
 	window.addEventListener("load", function () { gkMarbleAdj.disableThemeCusto(); });
 	const marbleObserver = {
 		observe: function (subject, topic, data) {


### PR DESCRIPTION
It's a marble fork so just having the check to check for okaeri without changing anything else just works.