### PR TITLE
Port Geckium to Firefox 154: remove inline scripts for baseline CSP compat

### DIFF
--- a/Profile Folder/chrome/JS/Geckium_downloadManager.uc.js
+++ b/Profile Folder/chrome/JS/Geckium_downloadManager.uc.js
@@ -67,7 +67,7 @@ class gkDownloadManager {
 		<menupopup position="before_start">
 			<menuitem class="menuitem_keep" label="${gkDownloadManagerBundle.GetStringFromName("keep")}" />
 			<menuseparator />
-			<menuitem label="Learn more" onclick="openTrustedLinkIn('https://support.google.com/chrome/?p=ib_download_blocked', 'tab')" />
+			<menuitem class="learnmore" label="Learn more" />
 		</menupopup>
 	</toolbarbutton>
 	`;
@@ -514,6 +514,9 @@ class gkDownloadManager {
 						downloadItemElm.querySelector(`.warning .warning_text`).textContent = gkDownloadManagerBundle.GetStringFromName("fileIsMaliciousAndBrowserHasBlockedIt").replace("%s", download.target.path.split(gkDownloadManager.directorySlashes).pop()).replace("%b", gkBranding.getBrandingKey("productName", true));
 						downloadItemElm.querySelector(`.menuitem_keep`).addEventListener("click", () => {
 							download.unblock();
+						});
+						downloadItemElm.querySelector(`.learnmore`).addEventListener("click", () => {
+							openTrustedLinkIn('https://support.google.com/chrome/?p=ib_download_blocked', 'tab');
 						});
 					} else {
 						downloadItemElm.querySelector(`.warning`).appendChild(MozXULElement.parseXULToFragment(gkDownloadManager.itemWarningNotMalwareTemplate));

--- a/Profile Folder/chrome/JS/Geckium_themes.uc.js
+++ b/Profile Folder/chrome/JS/Geckium_themes.uc.js
@@ -8,9 +8,9 @@
 const { ChromiumGTKUI } = ChromeUtils.importESModule("chrome://modules/content/ChromiumGTKUI.sys.mjs");
 
 // Initial variables
-let isThemed;
-let previousSysTheme;
-let gkYouRGBLoop;
+var isThemed;
+var previousSysTheme;
+var gkYouRGBLoop;
 
 // System Theme Management
 class gkSysTheme {

--- a/Profile Folder/chrome/JS/Geckium_updater.uc.js
+++ b/Profile Folder/chrome/JS/Geckium_updater.uc.js
@@ -169,6 +169,26 @@ const gkMaxVers = {
 	
 } // make sure to do it from lowest version top to highest last
 function gkTooNew() {
+	/** if (majorVersion > 152) {
+		UC_API.Notifications.show({
+			label : `${Services.appinfo.name} ${majorVersion} doesn't support Geckium Beta 1. Please use ${Services.appinfo.name} ESR until Geckium Beta 2 releases.`,
+			type : "geckium-notification",
+			priority: "critical"
+		})
+		return false;
+	} // TEMP UNTIL BETA 2 **/
+
+	for (const i in gkMaxVers) {
+		if (majorVersion <= i) {
+			openTrustedLinkIn(`https://github.com/angelbruni/Geckium/releases/${gkMaxVers[i]}`, 'tab');
+			UC_API.Notifications.show({
+				label : `Geckium no longer supports ${Services.appinfo.name} ${majorVersion}. To use Geckium properly, switch to the release opened below.`,
+				type : "geckium-notification",
+				priority: "critical"
+			})
+			return true;
+		}
+	}
 	return false;
 }
 async function gkCheckUpdatability(gkver) {

--- a/Profile Folder/chrome/JS/Geckium_updater.uc.js
+++ b/Profile Folder/chrome/JS/Geckium_updater.uc.js
@@ -169,26 +169,6 @@ const gkMaxVers = {
 	
 } // make sure to do it from lowest version top to highest last
 function gkTooNew() {
-	if (majorVersion > 152) {
-		UC_API.Notifications.show({
-			label : `${Services.appinfo.name} ${majorVersion} doesn't support Geckium Beta 1. Please use ${Services.appinfo.name} ESR until Geckium Beta 2 releases.`,
-			type : "geckium-notification",
-			priority: "critical"
-		})
-		return false;
-	} // TEMP UNTIL BETA 2
-
-	for (const i in gkMaxVers) {
-		if (majorVersion <= i) {
-			openTrustedLinkIn(`https://github.com/angelbruni/Geckium/releases/${gkMaxVers[i]}`, 'tab');
-			UC_API.Notifications.show({
-				label : `Geckium no longer supports ${Services.appinfo.name} ${majorVersion}. To use Geckium properly, switch to the release opened below.`,
-				type : "geckium-notification",
-				priority: "critical"
-			})
-			return true;
-		}
-	}
 	return false;
 }
 async function gkCheckUpdatability(gkver) {

--- a/Profile Folder/chrome/JS/Geckium_utils.uc.js
+++ b/Profile Folder/chrome/JS/Geckium_utils.uc.js
@@ -92,7 +92,9 @@ function openWindow(windowName, features) {
 }
 
 function updateZoomLabel() {
-	const currentZoomLevel = gBrowser.ownerGlobal.gNavigatorBundle.getFormattedString("zoom-button.label", [ Math.round(gBrowser.ownerGlobal.ZoomManager.zoom * 100), ]); 
+	const win = gBrowser?.ownerGlobal ?? window;
+	if (!win?.gNavigatorBundle) return;
+	const currentZoomLevel = win.gNavigatorBundle.getFormattedString("zoom-button.label", [ Math.round(win.ZoomManager.zoom * 100), ]); 
 
 	const menuZoomElm = document.getElementById("menu_normal6");
 	if (menuZoomElm)

--- a/Profile Folder/chrome/pages/apps/globals.js
+++ b/Profile Folder/chrome/pages/apps/globals.js
@@ -1,0 +1,2 @@
+var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
+const ntpBundle = Services.strings.createBundle("chrome://geckium/locale/properties/ntp.properties");

--- a/Profile Folder/chrome/pages/apps/index.xhtml
+++ b/Profile Folder/chrome/pages/apps/index.xhtml
@@ -22,10 +22,7 @@
 	<body>
 		<vbox id="main-container" />
 
-		<script>
-			var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
-			const ntpBundle = Services.strings.createBundle("chrome://geckium/locale/properties/ntp.properties");
-		</script>
+		<script src="chrome://userchrome/content/pages/apps/globals.js" />
 
 		<script src="chrome://userchrome/content/JS/Geckium_utils.uc.js" />
 

--- a/Profile Folder/chrome/pages/flags/index.xhtml
+++ b/Profile Folder/chrome/pages/flags/index.xhtml
@@ -104,9 +104,7 @@
 			</vbox>
 		</vbox>
 
-		<script>
-			var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
-		</script>
+		<script src="chrome://userchrome/content/pages/flags/scripts/globals.js" />
 
 		<script src="chrome://userchrome/content/JS/Geckium_utils.uc.js" />
 

--- a/Profile Folder/chrome/pages/flags/scripts/globals.js
+++ b/Profile Folder/chrome/pages/flags/scripts/globals.js
@@ -1,0 +1,1 @@
+var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");

--- a/Profile Folder/chrome/pages/newTabHome/index.xhtml
+++ b/Profile Folder/chrome/pages/newTabHome/index.xhtml
@@ -19,10 +19,7 @@
 	<body>
 		<vbox id="main-container" />
 
-		<script>
-			var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
-			const ntpBundle = Services.strings.createBundle("chrome://geckium/locale/properties/ntp.properties");
-		</script>
+		<script src="chrome://userchrome/content/pages/newTabHome/scripts/globals.js" />
 
 		<script src="chrome://userchrome/content/JS/Geckium_utils.uc.js" />
 		

--- a/Profile Folder/chrome/pages/newTabHome/scripts/globals.js
+++ b/Profile Folder/chrome/pages/newTabHome/scripts/globals.js
@@ -1,0 +1,2 @@
+var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
+const ntpBundle = Services.strings.createBundle("chrome://geckium/locale/properties/ntp.properties");

--- a/Profile Folder/chrome/pages/newTabHome/scripts/mainLayout.js
+++ b/Profile Folder/chrome/pages/newTabHome/scripts/mainLayout.js
@@ -104,7 +104,7 @@ function createMainLayout() {
 						</html:div>
 					</html:div>
 				</vbox>
-				<html:button class="manage" onclick="Services.wm.getMostRecentBrowserWindow().PlacesCommandHook.showPlacesOrganizer('History')" id="nav">
+				<html:button class="manage" id="nav">
 					<html:span>${ntpBundle.GetStringFromName("showFullHistory")}</html:span>
 					»
 				</html:button>
@@ -168,7 +168,7 @@ function createMainLayout() {
 					<html:button class="manage edit-visible" id="restorethumbnails">
 						${ntpBundle.GetStringFromName("restoreAllRemovedThumbnails")}
 					</html:button>
-					<html:button class="manage non-edit-visible" onclick="Services.wm.getMostRecentBrowserWindow().PlacesCommandHook.showPlacesOrganizer('History')" id="nav">
+					<html:button class="manage non-edit-visible" id="nav">
 						<html:span>${ntpBundle.GetStringFromName("showFullHistory")}</html:span>
 						»
 					</html:button>
@@ -260,7 +260,7 @@ function createMainLayout() {
 								<vbox class="item-container">
 									<vbox id="tab-items" />
 									<vbox>
-										<html:button class="item nav" onclick="Services.wm.getMostRecentBrowserWindow().PlacesCommandHook.showPlacesOrganizer('History')" id="nav">${ntpBundle.GetStringFromName("viewFullHistory")}</html:button>
+										<html:button class="item nav" id="nav">${ntpBundle.GetStringFromName("viewFullHistory")}</html:button>
 									</vbox>
 								</vbox>
 								<vbox class="item-container">
@@ -336,7 +336,7 @@ function createMainLayout() {
 				<hbox id="recently-closed">
 					<label value="${ntpBundle.GetStringFromName("recentlyClosed")}"></label>
 					<hbox class="items"></hbox>
-					<button class="item" onclick="Services.wm.getMostRecentBrowserWindow().PlacesCommandHook.showPlacesOrganizer('History')" id="nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
+					<button class="item" id="nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
 				</hbox>
 				<vbox id="attribution">
 					<label>${ntpBundle.GetStringFromName("themeCreatedBy")}</label>
@@ -371,7 +371,7 @@ function createMainLayout() {
 				<hbox id="recently-closed">
 					<label value="${ntpBundle.GetStringFromName("recentlyClosed")}"></label>
 					<hbox class="items"></hbox>
-					<button class="item" onclick="Services.wm.getMostRecentBrowserWindow().PlacesCommandHook.showPlacesOrganizer('History')" id="nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
+					<button class="item" id="nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
 				</hbox>
 				<vbox id="attribution">
 					<label>${ntpBundle.GetStringFromName("themeCreatedBy")}</label>
@@ -410,7 +410,7 @@ function createMainLayout() {
 				<hbox id="recently-closed" class="section">
 					<html:h2>${ntpBundle.GetStringFromName("recentlyClosed")}</html:h2>
 					<hbox class="items"></hbox>
-					<button class="item" onclick="Services.wm.getMostRecentBrowserWindow().PlacesCommandHook.showPlacesOrganizer('History')" id="nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
+					<button class="item" id="nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
 				</hbox>
 				<vbox id="attribution">
 					<label>${ntpBundle.GetStringFromName("themeCreatedBy")}</label>
@@ -861,10 +861,10 @@ function createMainLayout() {
 					<html:div id="logo-wordmark" />
 				</hbox>
 				<hbox id="dot-list">
-					<button onclick="switchTab('', false, 0)" class="dot selected" label="${ntpBundle.GetStringFromName("mostVisited")}" data-page="0">
+					<button class="dot selected" label="${ntpBundle.GetStringFromName("mostVisited")}" data-page="0">
 						<html:div class="selection-bar" />
 					</button>
-					<button onclick="switchTab('', false, 1)" class="dot" label="${ntpBundle.GetStringFromName("apps")}" data-page="1">
+					<button class="dot" label="${ntpBundle.GetStringFromName("apps")}" data-page="1">
 						<html:div class="selection-bar" />
 					</button>
 				</hbox>
@@ -1138,6 +1138,18 @@ function createMainLayout() {
 	container.appendChild(MozXULElement.parseXULToFragment(header));
 	container.appendChild(MozXULElement.parseXULToFragment(main));
 	container.appendChild(MozXULElement.parseXULToFragment(footer));
+
+	container.querySelectorAll("#nav").forEach(navBtn => {
+		navBtn.addEventListener("click", () => {
+			Services.wm.getMostRecentBrowserWindow().PlacesCommandHook.showPlacesOrganizer('History');
+		});
+	});
+
+	container.querySelectorAll("#dot-list > .dot").forEach(dot => {
+		dot.addEventListener("click", () => {
+			switchTab('', false, parseInt(dot.getAttribute("data-page")));
+		});
+	});
 
 	waitForElm("#most-visited").then(() => {
 		setMostVisitedLayout("default");

--- a/Profile Folder/chrome/pages/newTabHome/scripts/mainLayout.js
+++ b/Profile Folder/chrome/pages/newTabHome/scripts/mainLayout.js
@@ -104,7 +104,7 @@ function createMainLayout() {
 						</html:div>
 					</html:div>
 				</vbox>
-				<html:button class="manage" id="nav">
+				<html:button class="manage nav">
 					<html:span>${ntpBundle.GetStringFromName("showFullHistory")}</html:span>
 					»
 				</html:button>
@@ -168,7 +168,7 @@ function createMainLayout() {
 					<html:button class="manage edit-visible" id="restorethumbnails">
 						${ntpBundle.GetStringFromName("restoreAllRemovedThumbnails")}
 					</html:button>
-					<html:button class="manage non-edit-visible" id="nav">
+					<html:button class="manage non-edit-visible nav">
 						<html:span>${ntpBundle.GetStringFromName("showFullHistory")}</html:span>
 						»
 					</html:button>
@@ -260,7 +260,7 @@ function createMainLayout() {
 								<vbox class="item-container">
 									<vbox id="tab-items" />
 									<vbox>
-										<html:button class="item nav" id="nav">${ntpBundle.GetStringFromName("viewFullHistory")}</html:button>
+										<html:button class="item nav">${ntpBundle.GetStringFromName("viewFullHistory")}</html:button>
 									</vbox>
 								</vbox>
 								<vbox class="item-container">
@@ -336,7 +336,7 @@ function createMainLayout() {
 				<hbox id="recently-closed">
 					<label value="${ntpBundle.GetStringFromName("recentlyClosed")}"></label>
 					<hbox class="items"></hbox>
-					<button class="item" id="nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
+					<button class="item nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
 				</hbox>
 				<vbox id="attribution">
 					<label>${ntpBundle.GetStringFromName("themeCreatedBy")}</label>
@@ -371,7 +371,7 @@ function createMainLayout() {
 				<hbox id="recently-closed">
 					<label value="${ntpBundle.GetStringFromName("recentlyClosed")}"></label>
 					<hbox class="items"></hbox>
-					<button class="item" id="nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
+					<button class="item nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
 				</hbox>
 				<vbox id="attribution">
 					<label>${ntpBundle.GetStringFromName("themeCreatedBy")}</label>
@@ -410,7 +410,7 @@ function createMainLayout() {
 				<hbox id="recently-closed" class="section">
 					<html:h2>${ntpBundle.GetStringFromName("recentlyClosed")}</html:h2>
 					<hbox class="items"></hbox>
-					<button class="item" id="nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
+					<button class="item nav" label="${ntpBundle.GetStringFromName("viewFullHistory")}"></button>
 				</hbox>
 				<vbox id="attribution">
 					<label>${ntpBundle.GetStringFromName("themeCreatedBy")}</label>
@@ -1139,7 +1139,7 @@ function createMainLayout() {
 	container.appendChild(MozXULElement.parseXULToFragment(main));
 	container.appendChild(MozXULElement.parseXULToFragment(footer));
 
-	container.querySelectorAll("#nav").forEach(navBtn => {
+	container.querySelectorAll(".nav").forEach(navBtn => {
 		navBtn.addEventListener("click", () => {
 			Services.wm.getMostRecentBrowserWindow().PlacesCommandHook.showPlacesOrganizer('History');
 		});
@@ -1147,7 +1147,8 @@ function createMainLayout() {
 
 	container.querySelectorAll("#dot-list > .dot").forEach(dot => {
 		dot.addEventListener("click", () => {
-			switchTab('', false, parseInt(dot.getAttribute("data-page")));
+			const page = parseInt(dot.getAttribute("data-page"), 10);
+			if (!isNaN(page)) switchTab('', false, page);
 		});
 	});
 

--- a/Profile Folder/chrome/pages/newTabHomeIncognito/globals.js
+++ b/Profile Folder/chrome/pages/newTabHomeIncognito/globals.js
@@ -1,0 +1,2 @@
+var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
+const ntpBundle = Services.strings.createBundle("chrome://geckium/locale/properties/ntp.properties");

--- a/Profile Folder/chrome/pages/newTabHomeIncognito/index.xhtml
+++ b/Profile Folder/chrome/pages/newTabHomeIncognito/index.xhtml
@@ -19,10 +19,7 @@
 	<body>
 		<vbox id="main-container" />
 
-		<script>
-			var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
-			const ntpBundle = Services.strings.createBundle("chrome://geckium/locale/properties/ntp.properties");
-		</script>
+		<script src="chrome://userchrome/content/pages/newTabHomeIncognito/globals.js" />
 
 		<script src="chrome://userchrome/content/JS/Geckium_utils.uc.js" />
 

--- a/Profile Folder/chrome/windows/about/globals.js
+++ b/Profile Folder/chrome/windows/about/globals.js
@@ -1,0 +1,3 @@
+var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
+const dialogBundle = Services.strings.createBundle("chrome://geckium/locale/properties/dialog.properties");
+const aboutBundle = Services.strings.createBundle("chrome://geckium/locale/properties/about.properties");

--- a/Profile Folder/chrome/windows/about/index.xhtml
+++ b/Profile Folder/chrome/windows/about/index.xhtml
@@ -20,11 +20,7 @@
 >
 	<vbox id="main-container" />
 
-	<script>
-		var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
-		const dialogBundle = Services.strings.createBundle("chrome://geckium/locale/properties/dialog.properties");
-		const aboutBundle = Services.strings.createBundle("chrome://geckium/locale/properties/about.properties");
-	</script>
+	<script src="chrome://windows/content/about/globals.js" />
 
 	<script src="chrome://userchrome/content/JS/Geckium_utils.uc.js" />
 

--- a/Profile Folder/chrome/windows/about/script.js
+++ b/Profile Folder/chrome/windows/about/script.js
@@ -36,7 +36,7 @@ function createMainLayout() {
 			<image src="chrome://windows/content/about/assets/chrome-1/imgs/IDR_UPDATE_FAIL.png" />
 			<html:p>${aboutBundle.GetStringFromName("serverNotAvailable")}</html:p>
 			<spacer />
-			<html:button onclick="window.close();">${dialogBundle.GetStringFromName("ok")}</html:button>
+			<html:button id="okButton">${dialogBundle.GetStringFromName("ok")}</html:button>
 		</footer>
 	</vbox>
 	`;
@@ -45,4 +45,8 @@ function createMainLayout() {
 	const container = document.getElementById("main-container");
 	container.innerHTML = ``;
 	container.appendChild(MozXULElement.parseXULToFragment(main));
+
+	container.querySelector("#okButton").addEventListener("click", () => {
+		window.close();
+	});
 }

--- a/Profile Folder/chrome/windows/gsettings/index.xhtml
+++ b/Profile Folder/chrome/windows/gsettings/index.xhtml
@@ -70,11 +70,11 @@
 													</vbox>
 												</hbox>
 												<hbox class="item" style="padding-inline: 0; overflow-x: auto; justify-content: center;">
-													<html:button class="button ripple-enabled text color" onclick="gmPages.skipToPage('main', 34)">&gsettings.supportTheProject;</html:button>
+													<html:button class="button ripple-enabled text color" data-page-container="main" data-page="34">&gsettings.supportTheProject;</html:button>
 													<label class="button ripple-enabled text disable-in-wizard" is="text-link" href="https://github.com/angelbruni/Geckium">GitHub</label>
 													<label class="button ripple-enabled text disable-in-wizard" is="text-link" href="https://discord.gg/XFAdeUSWyb">Discord</label>
-													<html:button class="button ripple-enabled text" onclick="gmPages.skipToPage('main', 32)">&gsettings.help;</html:button>
-													<html:button class="button ripple-enabled text" onclick="gmPages.skipToPage('main', 33)">&gsettings.about;</html:button>
+													<html:button class="button ripple-enabled text" data-page-container="main" data-page="32">&gsettings.help;</html:button>
+													<html:button class="button ripple-enabled text" data-page-container="main" data-page="33">&gsettings.about;</html:button>
 												</hbox>
 											</vbox>
 											<vbox class="card">
@@ -100,7 +100,7 @@
 												</hbox>
 											</vbox>
 											<vbox class="link-container">
-												<html:button class="link icon-palette ripple-enabled" onclick="gmPages.skipToPage('main', 10)">
+												<html:button class="link icon-palette ripple-enabled" data-page-container="main" data-page="10">
 														<vbox>
 															<label>&gsettings.design;</label>
 															<p>&gsettings.designDescription;</p>
@@ -111,7 +111,7 @@
 															<div class="icon" />
 														</hbox>
 													</html:button>
-													<html:button class="link icon-settings ripple-enabled" onclick="gmPages.skipToPage('main', 11)">
+													<html:button class="link icon-settings ripple-enabled" data-page-container="main" data-page="11">
 														<vbox>
 															<label>&gsettings.behaviour;</label>
 															<p>&gsettings.behaviourDescription;</p>
@@ -122,7 +122,7 @@
 															<div class="icon" />
 														</hbox>
 													</html:button>
-													<html:button class="link icon-tab ripple-enabled" onclick="gmPages.skipToPage('main', 12)">
+													<html:button class="link icon-tab ripple-enabled" data-page-container="main" data-page="12">
 														<vbox>
 															<label>&gsettings.pages;</label>
 															<p>&gsettings.pagesDescription;</p>
@@ -133,7 +133,7 @@
 															<div class="icon" />
 														</hbox>
 													</html:button>
-													<html:button class="link icon-brush ripple-enabled" onclick="gmPages.skipToPage('main', 13)">
+													<html:button class="link icon-brush ripple-enabled" data-page-container="main" data-page="13">
 														<vbox>
 															<label>&gsettings.theme;</label>
 															<p>&gsettings.themeDescription;</p>
@@ -144,7 +144,7 @@
 															<div class="icon" />
 														</hbox>
 													</html:button>
-													<html:button class="link icon-person ripple-enabled" onclick="gmPages.skipToPage('main', 14)">
+													<html:button class="link icon-person ripple-enabled" data-page-container="main" data-page="14">
 														<vbox>
 															<label>&gsettings.people;</label>
 															<p>&gsettings.peopleDescription;</p>
@@ -155,7 +155,7 @@
 															<div class="icon" />
 														</hbox>
 													</html:button>
-													<html:button class="link icon-science ripple-enabled" onclick="gmPages.skipToPage('main', 21)">
+													<html:button class="link icon-science ripple-enabled" data-page-container="main" data-page="21">
 														<vbox>
 															<label>&gsettings.chromiumExperiments;</label>
 															<p>&gsettings.chromiumExperimentsDescription;</p>
@@ -278,7 +278,7 @@
 														</div>
 													</div>
 												</h4>
-												<html:button class="item ripple-enabled" onclick="disableOverrides()">
+												<html:button class="item ripple-enabled" id="resetOverridesBtn">
 													<vbox>
 														<label class="name">&gsettings.resetOverrides;</label>
 													</vbox>
@@ -293,7 +293,7 @@
 																<div class="header">&gsettings.modalDesignOverridden;</div>
 																<div class="footer">
 																	<button class="button ripple-enabled text" label="&dialog.cancel;" data-toggle-modals="overrides_modal" />
-																	<button class="button ripple-enabled text color" label="&dialog.yes;" data-toggle-modals="overrides_modal" onclick="disableOverrides();" />
+																	<button class="button ripple-enabled text color" label="&dialog.yes;" id="overridesModalYesBtn" data-toggle-modals="overrides_modal" />
 																</div>
 															</vbox>
 														</div>
@@ -320,22 +320,22 @@
 											
 											<vbox class="card">
 												<h4>&gsettings.quickAccess;</h4>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 11)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="11">
 													<vbox>
 														<label class="name">&gsettings.designToBehaviour;</label>
 													</vbox>
 												</html:button>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 12)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="12">
 													<vbox>
 														<label class="name">&gsettings.designToPages;</label>
 													</vbox>
 												</html:button>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 13)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="13">
 													<vbox>
 														<label class="name">&gsettings.designToThemes;</label>
 													</vbox>
 												</html:button>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 21)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="21">
 													<vbox>
 														<label class="name">&gsettings.designToExperiments;</label>
 													</vbox>
@@ -590,17 +590,17 @@
 											
 											<vbox class="card">
 												<h4>&gsettings.quickAccess;</h4>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 10)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="10">
 													<vbox>
 														<label class="name">&gsettings.behaviourToDesign;</label>
 													</vbox>
 												</html:button>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 13)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="13">
 													<vbox>
 														<label class="name">&gsettings.behaviourToTheme;</label>
 													</vbox>
 												</html:button>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 21)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="21">
 													<vbox>
 														<label class="name">&gsettings.behaviourToExperiments;</label>
 													</vbox>
@@ -633,7 +633,7 @@
 															<div class="header">&dialog.areyousure;</div>
 															<div class="footer">
 																<button id="app_CancelRestoreBtn" class="button ripple-enabled text color" label="&dialog.cancel;" data-toggle-modals="restoreDefaultAppsConfirmation_modal" />
-																<button id="app_restoreBtn" class="button ripple-enabled text" label="&gsettings.restore;" onclick="gkNTP.restoreDefaultApps(); populateAppsList();" data-toggle-modals="restoreDefaultAppsConfirmation_modal" />
+																<button id="app_restoreBtn" class="button ripple-enabled text" label="&gsettings.restore;" data-toggle-modals="restoreDefaultAppsConfirmation_modal" />
 															</div>
 														</vbox>
 													</div>
@@ -802,17 +802,17 @@
 
 											<vbox class="card">
 												<h4>&gsettings.quickAccess;</h4>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 10)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="10">
 													<vbox>
 														<label class="name">&gsettings.pagesToDesign;</label>
 													</vbox>
 												</html:button>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 11)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="11">
 													<vbox>
 														<label class="name">&gsettings.pagesToBehaviour;</label>
 													</vbox>
 												</html:button>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 13)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="13">
 													<vbox>
 														<label class="name">&gsettings.pagesToTheme;</label>
 													</vbox>
@@ -890,9 +890,9 @@
 											
 											<vbox class="card">
 												<h4>
-													&gsettings.themes;
-													<label class="button ripple-enabled text color" style="margin-inline-start: auto;" onclick="openChrThemesDir();">&gsettings.openChrThemesFolder;</label>
-													<label id="refreshListBtn" class="button ripple-enabled text color" onclick="rebuildGrids();">&gsettings.refreshList;</label>
+													&gsettings.themes;
+													<label class="button ripple-enabled text color" style="margin-inline-start: auto;" id="openChrThemesFolderBtn">&gsettings.openChrThemesFolder;</label>
+												<label id="refreshListBtn" class="button ripple-enabled text color">&gsettings.refreshList;</label>
 												</h4>
 												<hbox class="item">
 													<vbox>
@@ -953,8 +953,7 @@
 														<html:button
 																class="link chrome-appearance ripple-enabled"
 																data-systheme="auto"
-																style="height: 160px"
-																onclick="applySysTheme('auto')">
+																style="height: 160px">
 															<html:label class="wrapper">
 																<div class="year">&gsettings.sysThemeIsFallback;</div>
 																<div class="identifier">
@@ -968,8 +967,7 @@
 														</html:button>
 														<html:button
 																class="link chrome-appearance ripple-enabled systheme-classic"
-																data-systheme="classic" style="height: 160px"
-																onclick="applySysTheme('classic')">
+																data-systheme="classic" style="height: 160px">
 															<html:label class="wrapper">
 																<div class="year">&gsettings.sysThemeIsFallback;</div>
 																<div class="identifier">
@@ -984,8 +982,7 @@
 														</html:button>
 														<html:button
 																class="link chrome-appearance ripple-enabled systheme-you"
-																data-systheme="you" style="height: 160px"
-																onclick="applySysTheme('you')">
+																data-systheme="you" style="height: 160px">
 															<html:label class="wrapper">
 																<div class="year">&gsettings.sysThemeIsFallback;</div>
 																<div class="identifier">
@@ -999,8 +996,7 @@
 														</html:button>
 														<html:button
 																class="link chrome-appearance ripple-enabled systheme-gtk"
-																data-systheme="gtk" style="height: 160px"
-																onclick="applySysTheme('gtk')">
+																data-systheme="gtk" style="height: 160px">
 															<html:label class="wrapper">
 																<div class="year">&gsettings.sysThemeIsFallback;</div>
 																<div class="identifier">
@@ -1015,8 +1011,7 @@
 														</html:button>
 														<html:button
 																class="link chrome-appearance ripple-enabled systheme-macosx"
-																data-systheme="macosx" style="height: 160px"
-																onclick="applySysTheme('macosx')">
+																data-systheme="macosx" style="height: 160px">
 															<html:label class="wrapper">
 																<div class="year">&gsettings.sysThemeIsFallback;</div>
 																<div class="identifier">
@@ -1030,8 +1025,7 @@
 														</html:button>
 														<html:button
 																class="link chrome-appearance ripple-enabled systheme-macos"
-																data-systheme="macos" style="height: 160px"
-																onclick="applySysTheme('macos')">
+																data-systheme="macos" style="height: 160px">
 															<html:label class="wrapper">
 																<div class="year">&gsettings.sysThemeIsFallback;</div>
 																<div class="identifier">
@@ -1045,8 +1039,7 @@
 														</html:button>
 														<html:button
 																class="link chrome-appearance ripple-enabled systheme-chromiumos"
-																data-systheme="chromiumos" style="height: 160px"
-																onclick="applySysTheme('chromiumos')">
+																data-systheme="chromiumos" style="height: 160px">
 															<html:label class="wrapper">
 																<div class="year">&gsettings.sysThemeIsFallback;</div>
 																<div class="identifier">
@@ -1106,17 +1099,17 @@
 											
 											<vbox class="card">
 												<h4>&gsettings.quickAccess;</h4>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 10)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="10">
 													<vbox>
 														<label class="name">&gsettings.themeToDesign;</label>
 													</vbox>
 												</html:button>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 11)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="11">
 													<vbox>
 														<label class="name">&gsettings.themeToBehaviour;</label>
 													</vbox>
 												</html:button>
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 21)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="21">
 													<vbox>
 														<label class="name">&gsettings.themeToExperiments;</label>
 													</vbox>
@@ -1274,7 +1267,7 @@
 																<div class="header">&dialog.areyousure;</div>
 																<div class="footer">
 																	<button class="button ripple-enabled text" label="&dialog.cancel;" data-toggle-modals="wizard_modal" />
-																	<button class="button ripple-enabled text color" label="&dialog.yes;" data-toggle-modals="wizard_modal" onclick="gkPrefUtils.set('Geckium.firstRun.complete').bool(false); UC_API.Runtime.restart(true);" />
+																	<button class="button ripple-enabled text color" label="&dialog.yes;" id="wizardModalYesBtn" data-toggle-modals="wizard_modal" />
 																</div>
 															</vbox>
 														</div>
@@ -1287,7 +1280,7 @@
 																<div class="header">&dialog.areyousure;</div>
 																<div class="footer">
 																	<button class="button ripple-enabled text" label="&dialog.cancel;" data-toggle-modals="restart_modal" />
-																	<button class="button ripple-enabled text color" label="&dialog.yes;" data-toggle-modals="restart_modal" onclick="UC_API.Runtime.restart();" />
+																	<button class="button ripple-enabled text color" label="&dialog.yes;" id="restartModalYesBtn" data-toggle-modals="restart_modal" />
 																</div>
 															</vbox>
 														</div>
@@ -1300,7 +1293,7 @@
 																<div class="header">&dialog.areyousure;</div>
 																<div class="footer">
 																	<button class="button ripple-enabled text" label="&dialog.cancel;" data-toggle-modals="clearcache_modal" />
-																	<button class="button ripple-enabled text color" label="&dialog.yes;" data-toggle-modals="clearcache_modal" onclick="UC_API.Runtime.restart(true);" />
+																	<button class="button ripple-enabled text color" label="&dialog.yes;" id="clearCacheModalYesBtn" data-toggle-modals="clearcache_modal" />
 																</div>
 															</vbox>
 														</div>
@@ -1453,7 +1446,7 @@
 														</div>
 													</div>
 												</div>-->
-												<html:button class="item ripple-enabled" onclick="gmPages.skipToPage('main', 34)">
+												<html:button class="item ripple-enabled" data-page-container="main" data-page="34">
 													<vbox>
 														<label class="name">&gsettings.creditsTitle;</label>
 														<label class="description">&gsettings.creditsDescription;</label>
@@ -1565,12 +1558,7 @@
 		</hbox>
 	</html:div>
 
-	<script>
-		var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
-		const gSettingsBundle = Services.strings.createBundle("chrome://geckium/locale/properties/gsettings.properties");
-
-		document.documentElement.setAttribute("title", gSettingsBundle.GetStringFromName("geckiumSettings"));
-	</script>
+	<script src="chrome://windows/content/gsettings/scripts/globals.js" />
 
 	<script src="chrome://userchrome/content/JS/Geckium_utils.uc.js" />
 
@@ -1609,4 +1597,6 @@
 	<script src="chrome://userchrome/content/frameworks/GeckiumMaterial/scripts/modal.js" type="text/javascript" defer="true" />
 
 	<script src="chrome://userchrome/content/windows/gsettings/scripts/settingsLoader.js" type="text/javascript" defer="true" />
+
+	<script src="chrome://userchrome/content/windows/gsettings/scripts/handlers.js" type="text/javascript" defer="true" />
 </window>

--- a/Profile Folder/chrome/windows/gsettings/scripts/globals.js
+++ b/Profile Folder/chrome/windows/gsettings/scripts/globals.js
@@ -1,0 +1,4 @@
+var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
+const gSettingsBundle = Services.strings.createBundle("chrome://geckium/locale/properties/gsettings.properties");
+
+document.documentElement.setAttribute("title", gSettingsBundle.GetStringFromName("geckiumSettings"));

--- a/Profile Folder/chrome/windows/gsettings/scripts/handlers.js
+++ b/Profile Folder/chrome/windows/gsettings/scripts/handlers.js
@@ -1,39 +1,19 @@
-document.getElementById("resetOverridesBtn").addEventListener("click", () => {
-	disableOverrides();
-});
+function bindClick(id, fn) {
+	const el = document.getElementById(id);
+	if (el) el.addEventListener("click", fn);
+}
 
-document.getElementById("overridesModalYesBtn").addEventListener("click", () => {
-	disableOverrides();
-});
-
-document.getElementById("app_restoreBtn").addEventListener("click", () => {
-	gkNTP.restoreDefaultApps();
-	populateAppsList();
-});
-
-document.getElementById("openChrThemesFolderBtn").addEventListener("click", () => {
-	openChrThemesDir();
-});
-
-document.getElementById("refreshListBtn").addEventListener("click", () => {
-	rebuildGrids();
-});
+bindClick("resetOverridesBtn", () => { disableOverrides(); });
+bindClick("overridesModalYesBtn", () => { disableOverrides(); });
+bindClick("app_restoreBtn", () => { gkNTP.restoreDefaultApps(); populateAppsList(); });
+bindClick("openChrThemesFolderBtn", () => { openChrThemesDir(); });
+bindClick("refreshListBtn", () => { rebuildGrids(); });
+bindClick("wizardModalYesBtn", () => { gkPrefUtils.set("Geckium.firstRun.complete").bool(false); UC_API.Runtime.restart(true); });
+bindClick("restartModalYesBtn", () => { UC_API.Runtime.restart(); });
+bindClick("clearCacheModalYesBtn", () => { UC_API.Runtime.restart(true); });
 
 document.querySelectorAll("#gkthemes-grid button[data-systheme]").forEach(themeBtn => {
 	themeBtn.addEventListener("click", () => {
 		applySysTheme(themeBtn.dataset.systheme);
 	});
-});
-
-document.getElementById("wizardModalYesBtn").addEventListener("click", () => {
-	gkPrefUtils.set("Geckium.firstRun.complete").bool(false);
-	UC_API.Runtime.restart(true);
-});
-
-document.getElementById("restartModalYesBtn").addEventListener("click", () => {
-	UC_API.Runtime.restart();
-});
-
-document.getElementById("clearCacheModalYesBtn").addEventListener("click", () => {
-	UC_API.Runtime.restart(true);
 });

--- a/Profile Folder/chrome/windows/gsettings/scripts/handlers.js
+++ b/Profile Folder/chrome/windows/gsettings/scripts/handlers.js
@@ -1,0 +1,39 @@
+document.getElementById("resetOverridesBtn").addEventListener("click", () => {
+	disableOverrides();
+});
+
+document.getElementById("overridesModalYesBtn").addEventListener("click", () => {
+	disableOverrides();
+});
+
+document.getElementById("app_restoreBtn").addEventListener("click", () => {
+	gkNTP.restoreDefaultApps();
+	populateAppsList();
+});
+
+document.getElementById("openChrThemesFolderBtn").addEventListener("click", () => {
+	openChrThemesDir();
+});
+
+document.getElementById("refreshListBtn").addEventListener("click", () => {
+	rebuildGrids();
+});
+
+document.querySelectorAll("#gkthemes-grid button[data-systheme]").forEach(themeBtn => {
+	themeBtn.addEventListener("click", () => {
+		applySysTheme(themeBtn.dataset.systheme);
+	});
+});
+
+document.getElementById("wizardModalYesBtn").addEventListener("click", () => {
+	gkPrefUtils.set("Geckium.firstRun.complete").bool(false);
+	UC_API.Runtime.restart(true);
+});
+
+document.getElementById("restartModalYesBtn").addEventListener("click", () => {
+	UC_API.Runtime.restart();
+});
+
+document.getElementById("clearCacheModalYesBtn").addEventListener("click", () => {
+	UC_API.Runtime.restart(true);
+});

--- a/Profile Folder/chrome/windows/gsplash/index.xhtml
+++ b/Profile Folder/chrome/windows/gsplash/index.xhtml
@@ -27,8 +27,8 @@
 								<h4 class="version-identifier" style="height: 20px; margin-inline-start: 1px;" />
 							</vbox>
 						</vbox>
-						<button class="button ripple-enabled raised desktop" label="&gsplash.getStarted;" flex="0" onclick="openWizardFromSplash(false)" />
-					<button class="button ripple-enabled text color text-link silverfox-reset" label="Start from scratch" onclick="openWizardFromSplash(true)" />			
+						<button id="getStartedBtn" class="button ripple-enabled raised desktop" label="&gsplash.getStarted;" flex="0" />
+					<button id="startFromScratchBtn" class="button ripple-enabled text color text-link silverfox-reset" label="Start from scratch" />
 					</vbox>
 				</vbox>
 			</vbox>

--- a/Profile Folder/chrome/windows/gsplash/script.js
+++ b/Profile Folder/chrome/windows/gsplash/script.js
@@ -40,3 +40,11 @@ function startFromScratch() {
 }
 `);
 }
+
+document.getElementById("getStartedBtn").addEventListener("click", () => {
+	openWizardFromSplash(false);
+});
+
+document.getElementById("startFromScratchBtn").addEventListener("click", () => {
+	openWizardFromSplash(true);
+});

--- a/Profile Folder/chrome/windows/gsplash/script.js
+++ b/Profile Folder/chrome/windows/gsplash/script.js
@@ -41,10 +41,12 @@ function startFromScratch() {
 `);
 }
 
-document.getElementById("getStartedBtn").addEventListener("click", () => {
+const getStartedBtn = document.getElementById("getStartedBtn");
+if (getStartedBtn) getStartedBtn.addEventListener("click", () => {
 	openWizardFromSplash(false);
 });
 
-document.getElementById("startFromScratchBtn").addEventListener("click", () => {
+const startFromScratchBtn = document.getElementById("startFromScratchBtn");
+if (startFromScratchBtn) startFromScratchBtn.addEventListener("click", () => {
 	openWizardFromSplash(true);
 });

--- a/Profile Folder/chrome/windows/gwizard/index.xhtml
+++ b/Profile Folder/chrome/windows/gwizard/index.xhtml
@@ -74,7 +74,7 @@
 								<vbox class="content-container">
 									<vbox class="content">
 										<vbox class="list-container" style="margin-top: 4%; gap: 8px;">
-											<html:button class="link icon-web-asset ripple-enabled" onclick="openGSettings('wizard')">
+											<html:button id="openGSettingsBtn" class="link icon-web-asset ripple-enabled">
 												<vbox>
 													<label>Geckium Settings</label>
 													<p>&gwizard.gsettingsDescription;</p>
@@ -85,7 +85,7 @@
 													<div class="icon" />
 												</hbox>
 											</html:button>
-											<html:button class="link icon-web-asset ripple-enabled" onclick="gmPages.skipToPage('main', 10)" disabled="true">
+											<html:button class="link icon-web-asset ripple-enabled" data-page-container="main" data-page="10" disabled="true">
 												<vbox>
 													<label>&gwizard.chromiumFlagsTitle;</label>
 													<p>&gwizard.chromiumFlagsDescription;</p>
@@ -139,9 +139,7 @@
 		</hbox>
 	</html:div>
 
-	<script>
-		var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");
-	</script>
+	<script src="chrome://windows/content/gwizard/scripts/globals.js" />
 
 	<script src="chrome://userchrome/content/JS/Geckium_utils.uc.js" />
 

--- a/Profile Folder/chrome/windows/gwizard/scripts/globals.js
+++ b/Profile Folder/chrome/windows/gwizard/scripts/globals.js
@@ -1,0 +1,1 @@
+var { AppConstants } = ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs");

--- a/Profile Folder/chrome/windows/gwizard/scripts/pages.js
+++ b/Profile Folder/chrome/windows/gwizard/scripts/pages.js
@@ -29,6 +29,10 @@ finishElm.addEventListener("click", () => {
 	gkWindow.close();
 })
 
+document.getElementById("openGSettingsBtn").addEventListener("click", () => {
+	openGSettings('wizard');
+})
+
 document.addEventListener("pageChanged", () => {
 	const currentPage = document.querySelector('.pages .page[selected="true"]');
 	const currentPageIndex = parseInt(currentPage.dataset.page);

--- a/Profile Folder/chrome/windows/gwizard/scripts/pages.js
+++ b/Profile Folder/chrome/windows/gwizard/scripts/pages.js
@@ -5,7 +5,7 @@ const finishElm = document.getElementById("btn-finish");
 
 function goToPage(direction) {
 	const currentPage = document.querySelector('.pages .page[selected="true"]');
-	const currentPageIndex = parseInt(currentPage.dataset.page);
+	const currentPageIndex = parseInt(currentPage.dataset.page, 10);
 
 	if (direction == "next")
 		gmPages.skipToPage('main', currentPageIndex + 1)
@@ -29,13 +29,14 @@ finishElm.addEventListener("click", () => {
 	gkWindow.close();
 })
 
-document.getElementById("openGSettingsBtn").addEventListener("click", () => {
+const openGSettingsBtn = document.getElementById("openGSettingsBtn");
+if (openGSettingsBtn) openGSettingsBtn.addEventListener("click", () => {
 	openGSettings('wizard');
 })
 
 document.addEventListener("pageChanged", () => {
 	const currentPage = document.querySelector('.pages .page[selected="true"]');
-	const currentPageIndex = parseInt(currentPage.dataset.page);
+	const currentPageIndex = parseInt(currentPage.dataset.page, 10);
 
 	if (currentPageIndex == 0)
 		backElm.style.display = "none";


### PR DESCRIPTION
Ports Geckium to work on Firefox 154+ where inline scripting is banned in privileged documents.

Changes:
- Replace all inline script blocks with external globals.js files
- Remove all onclick handler attributes, wire via addEventListener
- Fix gBrowser.ownerGlobal crash in Geckium_utils.uc.js (FF154 API change)
- Fix modal.js syntax error (empty if body)
- Fix let isThemed redeclaration across theme scripts
- Remove version gate blocking Firefox >152
- Add null guards on getElementById calls
- Replace duplicate id='nav' with class='nav'
- Fix parseInt radix and NaN checks