### PR TITLE
Use the 32x icons for extensions (and a fix for positioning in 153)

### DIFF
--- a/Profile Folder/chrome/styles/partials/chrome/chrome-1/_toolbars.scss
+++ b/Profile Folder/chrome/styles/partials/chrome/chrome-1/_toolbars.scss
@@ -373,13 +373,20 @@
 			&[class*="webextension"] {
 				.toolbarbutton-icon {
 					width: 19px !important;
-					height: 19px !important;
+					height: auto !important;
 				}
 			}
 
 			&[class*="webextension"] {
+				--webextension-toolbar-image: var(--webextension-menupanel-image) !important;
+				--webextension-toolbar-image-dark: var(--webextension-menupanel-image-dark) !important;
 				overflow: visible !important;
-			} 
+
+				.toolbarbutton-badge-stack {
+					height: auto !important;
+					padding: 0 !important;
+				}
+			}
 		}
 	}
 	

--- a/Profile Folder/chrome/styles/partials/chrome/chrome-68/_toolbars.scss
+++ b/Profile Folder/chrome/styles/partials/chrome/chrome-68/_toolbars.scss
@@ -118,7 +118,7 @@
 		&#searchmode-switcher-button .toolbarbutton-icon,
 		&[class*="webextension"] .toolbarbutton-icon {
 			width: 16px !important;
-			height: 16px !important;
+			height: auto !important;
 		}
 	}
 }


### PR DESCRIPTION
Titleeeeeeeeeeeeeeee

I tried checking the most relevant versions for me and it doesn't seem to break them.

This PR also fixes an issue on 153 which is the following (Ignore the update symbol. It happens on latest as well):
<img width="150" height="122" alt="image" src="https://github.com/user-attachments/assets/8f6031cd-6840-4fe3-a72a-2b74f8f49de6" />

Screenshots:
Firefox 115 w/Chrome 1:
<img width="225" height="94" alt="image" src="https://github.com/user-attachments/assets/66378285-81d3-42e5-8266-755fce66b7a2" />

Nocturne 3.4.0 w/Chrome 25:
<img width="188" height="117" alt="image" src="https://github.com/user-attachments/assets/27a230f4-4669-4af9-9f79-8080848296b1" />

Nocturne 4.0 w/Chrome 47:
<img width="198" height="112" alt="image" src="https://github.com/user-attachments/assets/07b36b2e-12cc-4bbf-8439-2711f9206713" />

Nocturne 4.0 w/Chrome 58:
<img width="172" height="121" alt="image" src="https://github.com/user-attachments/assets/927792b3-ebe4-4567-ac8f-e5cae29b6598" />
